### PR TITLE
:bug: empty line missing after directive image

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,7 @@
 .. image:: https://raw.githubusercontent.com/Multiomics-Analytics-Group/acore/HEAD/docs/images/logo/acore_logo.svg
    :width: 400
    :alt: ACore Logo
+
 ==============
 Analytics Core
 ==============


### PR DESCRIPTION
It's probably time to make the README markdown as you suggested @sayalaruano .

it failed to publish the package to PyPI due to this:

```bash
ERROR    `long_description` has syntax errors in markup and would not be        
         rendered on PyPI.                                                      
         line 4: Warning: Explicit markup ends without a blank line; unexpected 
         unindent.       
```